### PR TITLE
Run command as a current user

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ docker run \
     -v ${RACK_DIR}:/opt/Rack:ro \
     -v ${WORKING_DIR}:/opt/workspace \
     -w /opt/workspace \
+    --user $(id -u):$(id -g) \
     --entrypoint "make" \
     --entrypoint "/bin/bash" \
 	${DOCKER_IMAGE_NAME} \


### PR DESCRIPTION
Run command as a current user to avoid creating of build artifact files with the root privileges which then are not handy to remove/overwrite.